### PR TITLE
Fix function overloading

### DIFF
--- a/src/endpoints/player/player-endpoint.interface.ts
+++ b/src/endpoints/player/player-endpoint.interface.ts
@@ -1,4 +1,4 @@
-import { IEndpointWrapper } from "abstract/endpoint/endpoint-wrapper.interface";
+import { IEndpointWrapper } from "../../abstract/endpoint/endpoint-wrapper.interface";
 
 export interface IPlayerEndpointWrapper extends IEndpointWrapper {
     play(): Promise<void>;

--- a/src/endpoints/recorder/recorder-endpoint.interface.ts
+++ b/src/endpoints/recorder/recorder-endpoint.interface.ts
@@ -1,6 +1,14 @@
 import { IEndpointWrapper } from "../../abstract/endpoint/endpoint-wrapper.interface";
 
 export interface IRecorderEndpointWrapper extends IEndpointWrapper {
+    on(event: "MediaFlowingIn", listener: (event: any) => void): this;
+
+    on(event: "MediaStoppedFlowingIn", listener: (event: any) => void): this;
+
+    on(event: "MediaFlowingOut", listener: (event: any) => void): this;
+
+    on(event: "MediaStoppedFlowingOut", listener: (event: any) => void): this;
+
     on(event: "RecordingStarted", listener: (event: any) => void): this;
 
     on(event: "RecordingStopped", listener: (event: any) => void): this;

--- a/src/endpoints/webrtc/webrtc-endpoint.interface.ts
+++ b/src/endpoints/webrtc/webrtc-endpoint.interface.ts
@@ -1,5 +1,12 @@
 import { IEndpointWrapper } from "../../abstract/endpoint/endpoint-wrapper.interface";
 
 export interface IWebRTCEndpointWrapper extends IEndpointWrapper{
+    on(event: "MediaFlowingIn", listener: (event: any) => void): this;
+
+    on(event: "MediaStoppedFlowingIn", listener: (event: any) => void): this;
+
+    on(event: "MediaFlowingOut", listener: (event: any) => void): this;
+
+    on(event: "MediaStoppedFlowingOut", listener: (event: any) => void): this;
     on(event: "ServerIceCandidate", listener: (candidate: any) => void): this;
 }


### PR DESCRIPTION
While I try to use the library for a university project I found two error:

1) A absolute include which is not resolved in a npm package
2) The known problem of the inherited function overload. I try to run it in a Docker and want to compile the hole project, but this error is blocking it. Therefore I used a workaround as described in
microsoft/TypeScript#10229. I know it is not a nice way, but it helps that I can use the lib